### PR TITLE
[BIA-981] Fixes link to the Web API in the index.html file.

### DIFF
--- a/Docs/index.html
+++ b/Docs/index.html
@@ -87,7 +87,7 @@
 
 	<h4>SharedInstance Assets</h4>
 	<ul><h3>Suite 3 v5.2.0</h3>
-		<li>API - <a href="https://chronic-absente/WebApi" target="_blank" >(Click here)</a>
+		<li>API - <a href="https://chronic-absente/EdFiOdsWebApi" target="_blank" >(Click here)</a>
 			<ul>
 				<li>Key: dqMi66UoBfLC</li>
 				<li>Secret: j65JETyk1WNmWKd9tbqMtPUt</li>
@@ -101,12 +101,6 @@
 			</ul>
 		</li>
 	</ul>
-		
-		<!-- <li><h3>Data Import</h3>  -->
-			<!-- <ul> -->
-				<!-- <li>Data Import - <a href="https://localhost/dataimport" target="_blank" >(Click here)</a></li> -->
-			<!-- </ul> -->
-		<!-- </li> -->
 	</div>
 	<br/><br/>
   </body>


### PR DESCRIPTION
From what I was able to see, the only change required here is fixing the link on the index.html file. The reason is that these scripts don't install the Web API.